### PR TITLE
AWS Authentication Refactor

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.18.5-alpine as builder
+RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates
 RUN mkdir /build 
 ADD ../ /build
 WORKDIR /build

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /build
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o ssm-sync ./cmd/ssm-sync
 
 FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/ssm-sync /app/
 WORKDIR /app
 CMD ["./ssm-sync"]

--- a/cmd/ssm-sync/main.go
+++ b/cmd/ssm-sync/main.go
@@ -31,10 +31,8 @@ import (
 //     "Statement": [
 //         {
 //             "Action": [
-//                 "ssm:GetParametersByPath",
-//                 "ssm:GetParameter",
+//                 "ssm:GetParameter*",
 //                 "ssm:PutParameter",
-//                 "ssm:GetParameters",
 //                 "ssm:ListTagsForResource",
 //                 "ssm:AddTagsToResource"
 //             ],
@@ -49,7 +47,11 @@ import (
 func main() {
 	log.Printf("INFO: ssm-sync started")
 
-	ssmClient, _ := auth.AwsAuth()
+	ssmClient, err := auth.AwsAuth()
+	if err != nil {
+		log.Fatalf("Authentication failed: %s", err.Error())
+	}
+
 	for {
 		log.Printf("INFO: sync start")
 		sync.Parameters(ssmClient, os.Getenv("SSM_PATH"))

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -26,7 +26,7 @@ func AwsAuth() (*ssm.Client, error) {
 		),
 	)
 	if err != nil {
-		log.Print("ERROR: config load error:", err)
+		return nil, err
 	}
 
 	client := sts.NewFromConfig(cfg)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,17 +13,17 @@ import (
 )
 
 func AwsAuth() (*ssm.Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*2))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*20))
 	defer cancel()
 
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(os.Getenv("AWS_REGION")),
+		config.WithSharedCredentialsFiles(
+			[]string{"/aws/credentials"},
+		),
 		config.WithWebIdentityRoleCredentialOptions(func(options *stscreds.WebIdentityRoleOptions) {
 			options.RoleSessionName = "IRSA_SSM_SYNC@" + os.Getenv("HOSTNAME")
 		}),
-		config.WithSharedCredentialsFiles(
-			[]string{"/aws/credentials", "/home/larntz/.aws/ssm-credentials"},
-		),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -22,7 +22,7 @@ func AwsAuth() (*ssm.Client, error) {
 			options.RoleSessionName = "IRSA_SSM_SYNC@" + os.Getenv("HOSTNAME")
 		}),
 		config.WithSharedCredentialsFiles(
-			[]string{"/aws-credentials", "/home/larntz/.aws/ssm-credentials"},
+			[]string{"/aws/credentials", "/home/larntz/.aws/ssm-credentials"},
 		),
 	)
 	if err != nil {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,33 +6,36 @@ import (
 	"os"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-func AwsAuth() (*ssm.Client, aws.Config) {
+func AwsAuth() (*ssm.Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*2))
 	defer cancel()
 
-	// running locally or in cluster?
-	_, local := os.LookupEnv("LOCAL")
-	if local {
-		cfg, err := config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(os.Getenv("AWS_PROFILE")))
-		if err != nil {
-			log.Fatal("config error:", err)
-		}
-		return ssm.NewFromConfig(cfg), cfg
-	}
-
-	os.Getenv("AWS_REGION")
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(os.Getenv("AWS_REGION")),
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(os.Getenv("AWS_REGION")),
 		config.WithWebIdentityRoleCredentialOptions(func(options *stscreds.WebIdentityRoleOptions) {
 			options.RoleSessionName = "IRSA_SSM_SYNC@" + os.Getenv("HOSTNAME")
-		}))
+		}),
+		config.WithSharedCredentialsFiles(
+			[]string{"/aws-credentials", "/home/larntz/.aws/ssm-credentials"},
+		),
+	)
 	if err != nil {
-		log.Fatal("config error:", err)
+		log.Print("ERROR: config load error:", err)
 	}
-	return ssm.NewFromConfig(cfg), cfg
+
+	client := sts.NewFromConfig(cfg)
+	identity, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("INFO: sts identity: %s", *identity.Arn)
+
+	return ssm.NewFromConfig(cfg), nil
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -39,7 +39,7 @@ func Parameters(ssmClient *ssm.Client, path string) {
 				// sync to destination regions
 				if *tag.Key == "ssm-replicate-regions" {
 					for _, region := range strings.Split(*tag.Value, ":") {
-						go syncParam(*param.Name, *param.ARN, region)
+						go syncParam(ssmClient, *param.Name, *param.ARN, region)
 					}
 				}
 			}

--- a/internal/sync/sync_param.go
+++ b/internal/sync/sync_param.go
@@ -3,22 +3,24 @@ package sync
 import (
 	"context"
 	"log"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmType "github.com/aws/aws-sdk-go-v2/service/ssm/types"
-	"github.com/larntz/ssm-sync/internal/auth"
 )
 
-func syncParam(name string, arn string, destRegion string) {
+func syncParam(ssmClient *ssm.Client, name string, arn string, destRegion string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*5))
 	defer cancel()
 
 	sourceRegion := GetRegion(arn)
 
-	ssmClient, cfg := auth.AwsAuth()
+	//ssmClient, cfg := auth.AwsAuth()
 	getParamInput := ssm.GetParameterInput{
 		Name:           &name,
 		WithDecryption: aws.Bool(true),
@@ -32,7 +34,18 @@ func syncParam(name string, arn string, destRegion string) {
 	}
 
 	destParamName := strings.Replace(name, sourceRegion, destRegion, -1)
-	destCfg := cfg
+	destCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(os.Getenv("AWS_REGION")),
+		config.WithWebIdentityRoleCredentialOptions(func(options *stscreds.WebIdentityRoleOptions) {
+			options.RoleSessionName = "IRSA_SSM_SYNC@" + os.Getenv("HOSTNAME")
+		}),
+		config.WithSharedCredentialsFiles(
+			[]string{"/aws-credentials", "/home/larntz/.aws/ssm-credentials"},
+		),
+	)
+	if err != nil {
+		log.Print("ERROR: config load error:", err)
+	}
 	destCfg.Region = destRegion
 	destSsmClient := ssm.NewFromConfig(destCfg)
 	destParameterInput := ssm.PutParameterInput{

--- a/internal/sync/util.go
+++ b/internal/sync/util.go
@@ -25,7 +25,7 @@ func lookupDestinationParam(ctx context.Context, client *ssm.Client, name string
 		WithDecryption: aws.Bool(true),
 	}
 
-	param, err := client.GetParameter(ctx, &getParamInput)
+	param, err := client.GetParameter(ctx, &getParamInput, func(options *ssm.Options) { options.Region = destRegion })
 	if err != nil {
 		var pnf *ssmType.ParameterNotFound
 		if errors.As(err, &pnf) {
@@ -40,7 +40,7 @@ func lookupDestinationParam(ctx context.Context, client *ssm.Client, name string
 
 	exists = true
 
-	output, err := client.ListTagsForResource(ctx, &ssm.ListTagsForResourceInput{ResourceId: param.Parameter.Name, ResourceType: "Parameter"})
+	output, err := client.ListTagsForResource(ctx, &ssm.ListTagsForResourceInput{ResourceId: param.Parameter.Name, ResourceType: "Parameter"}, func(options *ssm.Options) { options.Region = destRegion })
 	if err != nil {
 		log.Printf("failed to get tags for %s\nerr: %s", name, err)
 	}


### PR DESCRIPTION
Refactoring how authentication is done to allow for working with different types of credentials and credential paths. 

- refactored to only authenticate at start
- refactored to use only one ssm client and override regions when syncing 
